### PR TITLE
Some bugs fixed

### DIFF
--- a/hyperv-attachment/src/hypercall/hypercall.cpp
+++ b/hyperv-attachment/src/hypercall/hypercall.cpp
@@ -163,7 +163,7 @@ std::uint8_t copy_stack_data_from_log_exit(std::uint64_t* const stack_data, cons
             return 0;
         }
 
-        crt::copy_memory(reinterpret_cast<std::uint8_t*>(stack_data) + bytes_read, reinterpret_cast<const std::uint8_t*>(rsp_mapped) + bytes_read, size_to_read);
+        crt::copy_memory(reinterpret_cast<std::uint8_t*>(stack_data) + bytes_read, rsp_mapped, size_to_read);
 
         bytes_remaining -= size_to_read;
         bytes_read += size_to_read;

--- a/hyperv-attachment/src/slat/hook/amd_page_split.cpp
+++ b/hyperv-attachment/src/slat/hook/amd_page_split.cpp
@@ -78,8 +78,8 @@ void slat::hook::unfix_split_instructions(const entry_t* const hook_entry, const
 		}
 	}
 
-	// no nearby hooks enough to have to shed executability
-	set_previous_page_executability(slat_cr3, target_guest_address, 0);
-	set_next_page_executability(slat_cr3, target_guest_address, 0);
+	// no nearby hooks, restore both adjacent pages to non-executable
+	set_previous_page_executability(slat_cr3, target_guest_address, 1);
+	set_next_page_executability(slat_cr3, target_guest_address, 1);
 }
 #endif


### PR DESCRIPTION
**Bug 1 AMD hook removal leaves adjacent pages executable**
File:
_amd_page_split.cpp_

What was happening
When removing an AMD hook that had no other nearby hooks in the same 2MB range, unfix_split_instructions was supposed to restore the adjacent pages (prev/next) in hook_cr3 back to nonexecutable. Instead, it was calling set_previous/next_page_executability with execute_disable = 0, which keeps them executable the exact same thing fix_split_instructions does when adding a hook.

Why that was bad
After removing a hook, the adjacent pages in hook_cr3 stayed executable when they shouldnt be. This means if code happened to land on those pages while on hook_cr3, it would execute without triggering an NPF back to hyperv_cr3. Effectively, the hook teardown was leaking executable permissions, making the NX-enforcement on hook_cr3 weaker with every hook add/remove cycle. Over time, this could cause hooks to not fire correctly or let unhooked code run from the wrong SLAT context.

The fix
Changed both calls from execute_disable = 0 to execute_disable = 1, so adjacent pages are properly restored to NX when no nearby hook needs them anymore. This matches the intent hook_cr3 pages are NX by default, and only hooked pages (plus their neighbors for split instruction support) should ever be executable


**Bug 2 Stack data copy double offsets the source pointer on cross page reads**

What was happening
In copy_stack_data_from_log_exit, the code translates rsp + bytes_read to a guest physical address, then maps that physical address to get rsp_mapped. At this point, rsp_mapped already points to the correct location in physical memory. But then the copy call was adding bytes_read to rsp_mapped again, doublecounting the offset

Why that was bad
On the first loop iteration (bytes_read = 0), everything worked fine. But if the stack data spanned a page boundary and triggered a second iteration, the source pointer would be offset by bytes_read past where it should be reading from completely wrong physical memory. This could produce garbage stack trace data in logs, or worse, read from unmapped memory and cause unpredictable behavior during the log exit path.

The fix
Removed the bytes_read offset from the source pointer since rsp_mapped is already mapped from the correctly offset addresss